### PR TITLE
update license in package file to match repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "renderer"
   ],
   "author": "Tyler J. Cagle",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/tjcages/expo-link-preview/issues"
   },


### PR DESCRIPTION
I noticed your license in the `package.json` is ISC, while the actual license file is MIT. Thought you would want to sync this :)