### PR TITLE
CJ | Adding in react import so that way users are not enforced to specific babel plugins

### DIFF
--- a/src/components/Themed.js
+++ b/src/components/Themed.js
@@ -2,7 +2,7 @@
  * Learn more about Light and Dark modes:
  * https://docs.expo.io/guides/color-schemes/
  */
-
+import react from 'react';
  import {
   Text as DefaultText,
   View as DefaultView,


### PR DESCRIPTION


A small PR to address the following issue:
https://github.com/tjcages/expo-link-preview/issues/4